### PR TITLE
fix(os): proper support for windows os

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -46,6 +46,12 @@ describe('Terminal Launcher', () => {
       Object.defineProperty(process, 'platform', {
         value: 'win32'
       })
+
+      Object.defineProperty(process, 'env', {
+        value: {
+          PATHEXT: '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC'
+        }
+      })
     })
 
     beforeEach(() => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,5 +1,10 @@
+/* eslint-disable security/detect-child-process */
 const TerminalLauncher = require('../index')
+const getTerminals = require('../lib/get-terminals')
+
 const opn = require('opn')
+const childProcess = require('child_process')
+
 jest.mock('opn')
 
 describe('Terminal Launcher', () => {
@@ -9,20 +14,75 @@ describe('Terminal Launcher', () => {
     }).toThrow()
   })
 
-  test('launching a terminal calls opn with the correct params', async () => {
-    const path = '/usr/local/bin/non-existent.sh'
+  describe('Linux', () => {
+    beforeAll(() => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux'
+      })
+    })
 
-    await TerminalLauncher.launchTerminal({path})
-    expect(opn).toHaveBeenCalled()
+    test('launching a terminal calls opn with the correct params when running on linux', async () => {
+      const path = '/usr/local/bin/non-existent.sh'
 
-    const calledWithFirstArgument = opn.mock.calls[0][0]
-    expect(calledWithFirstArgument).toEqual(path)
+      await TerminalLauncher.launchTerminal({path})
+      expect(opn).toHaveBeenCalled()
+
+      const calledWithFirstArgument = opn.mock.calls[0][0]
+      expect(calledWithFirstArgument).toEqual(path)
+    })
+
+    describe('get-terminals returns array of functions', () => {
+      test('terminals are a list of functions', () => {
+        const terminals = getTerminals('mock.ext')
+        expect(Array.isArray(terminals)).toBeTruthy()
+        expect(terminals.length).toBeTruthy()
+        expect(typeof terminals[0] === 'function').toBeTruthy()
+      })
+    })
   })
 
-  test('terminals are a list of functions', () => {
-    const terminals = TerminalLauncher.getTerminals()
-    expect(Array.isArray(terminals)).toBeTruthy()
-    expect(terminals.length).toBeTruthy()
-    expect(typeof terminals[0] === 'function').toBeTruthy()
+  describe('Windows', () => {
+    beforeAll(() => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32'
+      })
+    })
+
+    beforeEach(() => {
+      childProcess.exec = jest.fn(() => ({once: (type, c) => type === 'close' && c(0)}))
+    })
+
+    describe('launching a terminal calls child_process.exec with the correct command', () => {
+      test('for powershell scripts', async () => {
+        const path = 'C:\\script.ps1'
+        const expectedCommand = 'start powershell "C:\\script.ps1"'
+
+        await TerminalLauncher.launchTerminal({path})
+        expect(childProcess.exec).toHaveBeenCalled()
+
+        const calledWithFirstArgument = childProcess.exec.mock.calls[0][0]
+        expect(calledWithFirstArgument).toEqual(expectedCommand)
+      })
+
+      test('for bat scripts', async () => {
+        const path = 'C:\\script.bat'
+        const expectedCommand = 'start cmd /c "C:\\script.bat"'
+
+        await TerminalLauncher.launchTerminal({path})
+        expect(childProcess.exec).toHaveBeenCalled()
+
+        const calledWithFirstArgument = childProcess.exec.mock.calls[0][0]
+        expect(calledWithFirstArgument).toEqual(expectedCommand)
+      })
+    })
+
+    describe('get-terminals returns array of functions', () => {
+      test('terminals are a list of functions', () => {
+        const terminals = getTerminals('mock.ext')
+        expect(Array.isArray(terminals)).toBeTruthy()
+        expect(terminals.length).toBeTruthy()
+        expect(typeof terminals[0] === 'function').toBeTruthy()
+      })
+    })
   })
 })

--- a/lib/TerminalLauncher.js
+++ b/lib/TerminalLauncher.js
@@ -1,21 +1,6 @@
 'use strict'
-const opn = require('opn')
+const getTerminals = require('./get-terminals')
 const debug = require('debug')('opn-shell')
-
-const terminalAppsInfo = [
-  // MacOS variations of terminal apps
-  'Hyper',
-  'iTerm',
-  'terminal.app',
-  // Linux variations of terminal apps
-  ['x-terminal-emulator', '-e'],
-  ['gnome-terminal', '-e'],
-  ['konsole', '-e'],
-  ['xterm', '-e'],
-  ['urxvt', '-e'],
-  [process.env.COLORTERM, '-e'],
-  [process.env.XTERM, '-e']
-]
 
 class TerminalLauncher {
   static launchTerminal({path} = {}) {
@@ -24,21 +9,13 @@ class TerminalLauncher {
     }
 
     debug('executing: %s', path)
-    const shellLauncher = TerminalLauncher.getTerminals(path).reduce((promise, nextPromise) => {
-      return promise.catch(nextPromise)
-    }, Promise.reject()) /* eslint prefer-promise-reject-errors: "off" */
+
+    const shellLauncher = getTerminals(path).reduce(
+      (promise, nextPromise) => promise.catch(nextPromise),
+      Promise.reject()
+    ) /* eslint prefer-promise-reject-errors: "off" */
 
     return shellLauncher
-  }
-
-  static getTerminals(path) {
-    const terminalApps = terminalAppsInfo.map(appInfo => {
-      debug('adding terminal configuration: %s', appInfo.toString())
-      return () => opn(path, {app: appInfo})
-    })
-
-    terminalApps.push(() => opn(path))
-    return terminalApps
   }
 }
 

--- a/lib/get-terminals-linux.js
+++ b/lib/get-terminals-linux.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const opn = require('opn')
+const debug = require('debug')('opn-shell')
+
+function getLinuxTerminalHandlers(path) {
+  const terminalApps = [
+    // MacOS variations of terminal apps
+    'Hyper',
+    'iTerm',
+    'terminal.app',
+    // Linux variations of terminal apps
+    ['x-terminal-emulator', '-e'],
+    ['gnome-terminal', '-e'],
+    ['konsole', '-e'],
+    ['xterm', '-e'],
+    ['urxvt', '-e'],
+    [process.env.COLORTERM, '-e'],
+    [process.env.XTERM, '-e']
+  ]
+
+  const handlers = terminalApps.map(appInfo => {
+    debug('adding terminal configuration: %s', appInfo.toString())
+    return () => opn(path, {app: appInfo})
+  })
+
+  handlers.push(() => opn(path))
+  return handlers
+}
+
+module.exports = getLinuxTerminalHandlers

--- a/lib/get-terminals-windows.js
+++ b/lib/get-terminals-windows.js
@@ -1,0 +1,42 @@
+/* eslint-disable security/detect-child-process */
+'use strict'
+
+const debug = require('debug')('opn-shell')
+const path = require('path')
+const childProcess = require('child_process')
+
+function getWindowsTerminalHandlers(scriptPath) {
+  const extension = path.extname(scriptPath).toLowerCase()
+  const logAddedTerminal = terminal => debug(`'adding terminal configuration: ${terminal}'`)
+
+  let command
+  if (getCmdSupportedExtensions().includes(extension)) {
+    command = `start cmd /c "${scriptPath}"`
+    logAddedTerminal('cmd')
+  } else {
+    command = `start powershell "${scriptPath}"`
+    logAddedTerminal('powershell')
+  }
+
+  const handler = () =>
+    new Promise((resolve, reject) => {
+      const cp = childProcess.exec(command)
+
+      cp.once('error', reject)
+      cp.once(
+        'close',
+        code => (code === 0 ? resolve(cp) : reject(new Error('Exited with code ' + code)))
+      )
+    })
+
+  return [handler]
+}
+
+function getCmdSupportedExtensions() {
+  // PATHEXT contains semicolon separated list of file extensions which are considered to be executable by Windows
+  // (runnable by cmd)
+  const extensions = process.env.PATHEXT.toLowerCase().split(';')
+  return extensions
+}
+
+module.exports = getWindowsTerminalHandlers

--- a/lib/get-terminals.js
+++ b/lib/get-terminals.js
@@ -1,0 +1,10 @@
+'use strict'
+
+function getTerminals(executablePath) {
+  const module = /^win/i.test(process.platform)
+    ? './get-terminals-windows'
+    : './get-terminals-linux'
+  return require(module)(executablePath)
+}
+
+module.exports = getTerminals


### PR DESCRIPTION
Implemented proper handling of windows script and executable files.

## Description

Script files in Windows [are not executables on their own.](https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows) Windows isn't friendly when it comes to replacing default shell, so defering to cmd.exe for executables (bat, exes, etc. - these extensions are actually defined in env variable) and powershell for the rest seems like an optimal way to accomplish this task.

Please make sure to pay extra attention to the testing while reviewing - I was using jest for the first time.

## Types of changes

I'm considering it as a bug because it did not work and/or was not tested on Windows previously.

- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#5 

## How Has This Been Tested?

- Manual CLI testing on Windows 10
- New test cases that covers windows related functionality

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation (if required).
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] [I added a picture of a cute animal cause it's fun](https://imgur.com/MQHYB)
